### PR TITLE
Upgrade Kotlin to version 2.0.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ repositories {
 
 dependencies {
     // Detekt plugins
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.5")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.7")
 
     // Use bundles for better organization
     implementation(libs.bundles.spring.boot.web)
@@ -97,5 +97,4 @@ detekt {
     buildUponDefaultConfig = true
     allRules = false
     config.setFrom("$projectDir/detekt.yml")
-    ignoreFailures = true // Temporarily ignore failures to test
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.9.23"
+kotlin = "2.0.10"
 spring-boot = "3.5.4"
 spring-dependency-management = "1.1.7"
 testcontainers = "1.20.4"
@@ -10,7 +10,7 @@ postgresql = "42.7.5"
 r2dbc-postgresql = "1.0.7.RELEASE"
 spring-session = "3.4.0"
 kotlinx-coroutines = "1.9.0"
-detekt = "1.23.6"
+detekt = "1.23.7"
 ktlint = "12.1.0"
 
 [libraries]


### PR DESCRIPTION
Note: There's a higher version available but 2.0.10 is the highest compatible version for Detekt Gradle plugin.