### PR TITLE
Set up pre-commit hooks for development

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  # Kotlin linting and formatting
+  - repo: local
+    hooks:
+      # KtLint formatting check
+      - id: ktlint-check
+        name: ktlint check
+        entry: ./gradlew ktlintCheck
+        language: system
+        files: \.kt$
+        pass_filenames: false
+
+      # Detekt linting
+      - id: detekt
+        name: detekt
+        entry: ./gradlew detekt
+        language: system
+        files: \.kt$
+        pass_filenames: false
+
+      # Run tests
+      - id: gradle-test
+        name: gradle test
+        entry: ./gradlew test
+        language: system
+        files: \.(kt|kts|java|properties|yaml|yml)$
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
 # Astronauth
 This project uses **Spring Boot** and **Kotlin**.
 
+## Pre-commit Setup
+This project uses pre-commit hooks to ensure code quality. To set up:
+
+1. Install pre-commit: `pip3 install pre-commit`
+2. Install hooks: `pre-commit install`
+
+The hooks will automatically run:
+- **ktlint** for Kotlin formatting and style checks
+- **detekt** for static code analysis  
+- **tests** to ensure all tests pass
+
+### Docker Configuration for Tests
+Tests use testcontainers and require Docker to be running. Configuration depends on your Docker setup:
+
+**For Docker Desktop users:** No additional configuration needed.
+
+**For Lima Docker users:** Set these environment variables in your shell:
+```bash
+export DOCKER_HOST=unix:///Users/$USER/.lima/docker/sock/docker.sock
+export TESTCONTAINERS_HOST_OVERRIDE=127.0.0.1
+export TESTCONTAINERS_RYUK_DISABLED=true
+```
+
+**For other Docker setups:** Configure `DOCKER_HOST` to point to your Docker daemon socket.
+
 ## Setup IntelliJ
 ### Running Docker externally
 If you run Docker externally (e.g. using Lima), you should add the following:


### PR DESCRIPTION
Added pre-commit hooks that automatically lint, format, and test Kotlin code before commits. 

This includes documentation for installing the pre-commit hook and making sure running them works with Docker setups (like Lima).